### PR TITLE
Add rubocop-graphql config

### DIFF
--- a/config/graphql.yml
+++ b/config/graphql.yml
@@ -1,0 +1,37 @@
+require: rubocop-graphql
+
+# This cop insists that all resolver and mutation arguments have a description.
+# We believe it is valuable to have descriptions for arguments which need
+# additional explanation, however we're not convinced it is useful to enforce them
+# for everything since this leads to a lot of unnecessary descriptions for example:
+#
+# class UserResolver < BaseResolver
+#   argument :id, GraphQL::Types::ID, description: "ID of the user", null: false
+# end
+#
+GraphQL/ArgumentDescription:
+  Enabled: false
+
+# This cop insists that all fields have a description.
+# We believe it is valuable to have descriptions for fields which need
+# additional explanation, however we're not convinced it is useful to enforce them
+# for everything since this leads to a lot of unnecessary descriptions for example:
+#
+# class UserType < Types::BaseObject
+#   field :id, GraphQL::Types::ID, description: "ID of the user", null: false
+# end
+#
+GraphQL/FieldDescription:
+  Enabled: false
+
+# This cop insists that all of our types have a description.
+# We believe it is valuable to have descriptions for fields which need
+# additional explanation, however we're not convinced it is useful to enforce them
+# for everything since this leads to a lot of unnecessary descriptions for example:
+#
+# class UserType < Types::BaseObject
+#   description "A user."
+# end
+#
+GraphQL/ObjectDescription:
+  Enabled: false

--- a/rubocop-futurelearn.gemspec
+++ b/rubocop-futurelearn.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["config/**/*", "*.markdown"]
 
   spec.add_dependency "rubocop", "~> 1.14.0"
+  spec.add_dependency "rubocop-graphql", "~> 0.8.2"
   spec.add_dependency "rubocop-rails", "~> 2.7.1"
   spec.add_dependency "rubocop-rspec", "~> 2.3.0"
   spec.add_dependency "rubocop-thread_safety", "~> 0.4.0"


### PR DESCRIPTION
We recently started using rubocop-graphql as a first attempt at bringing some consistency to how write GraphQL code.

Now that we have a separate repo for managing our rubocop config this feels like the natural place for this config.

There are a number of cops which have been overridden, most of which are cops which enforce descriptions for everything. I believe that descriptions are valuable when something needs additional explanation, however I don't think we should be enforcing them for everything given that this will lead to a lot of unnecessary descriptions for example:

```ruby
class UserType < BaseType
  field :id, GraphQL::Types::ID, description: "ID of the user", null: false
end
```